### PR TITLE
Fix tfsec to redirect stderr to /dev/null.

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -6,7 +6,7 @@ if [ -n "${GITHUB_WORKSPACE}" ]; then
   cd "${GITHUB_WORKSPACE}" || exit
 fi
 
-if ! tfsec --format=json "${INPUT_WORKING_DIRECTORY}" >results.json; then
+if ! tfsec --format=json "${INPUT_WORKING_DIRECTORY}" 2>/dev/null >results.json; then
   echo "tfsec violations were identified, running commenter..."
   commenter
 fi


### PR DESCRIPTION
If the module is not found or relative paths cannot be resolved. when tfsec is executed, stderr will be given. In the unmodified script, the stderr is also included in the file and the commenter is not executed correctly.
Therefore, the stderr is now output to /dev/null in this fix.

example stderr of tfsec is shown bellow:
```
WARNING: Failed to load module: failed to load module constants_waf: open /Users/fuga/sample/waf
WARNING: Failed to load module: missing module with source 'git::ssh://git@github.com
```
 