### PR TITLE
Add URL links contained in tfsec results to comment output

### DIFF
--- a/cmd/commenter/commenter.go
+++ b/cmd/commenter/commenter.go
@@ -76,8 +76,10 @@ func generateErrorMessage(result result) string {
 
 %s
 
-For more information, see https://tfsec.dev/docs/%s/%s/`,
-		result.RuleID, result.Description, strings.ToLower(result.RuleProvider), result.RuleID)
+For more information, see:
+
+%s`,
+		result.RuleID, result.Description, formatUrls(result.Links))
 }
 
 func extractPullRequestNumber() (int, error) {
@@ -94,6 +96,14 @@ func extractPullRequestNumber() (int, error) {
 	payload := data.(map[string]interface{})
 
 	return strconv.Atoi(fmt.Sprintf("%v", payload["number"]))
+}
+
+func formatUrls(urls []string) string {
+	urlList := ""
+	for _, url := range urls {
+		urlList += fmt.Sprintf("- %s\n", url)
+	}
+	return urlList
 }
 
 func fail(err string) {

--- a/cmd/commenter/resultsProcessor.go
+++ b/cmd/commenter/resultsProcessor.go
@@ -15,7 +15,7 @@ type result struct {
 	RuleID          string      `json:"rule_id"`
 	RuleDescription string      `json:"rule_description"`
 	RuleProvider    string      `json:"rule_provider"`
-	Link            string      `json:"link"`
+	Links           []string    `json:"links"`
 	Range           *checkRange `json:"location"`
 	Description     string      `json:"description"`
 	RangeAnnotation string      `json:"-"`


### PR DESCRIPTION
Due to the recent reorganiation of the tfsec official website, the URL links contained in the tfsec-pr-commenter's comments like this

<img width="637" alt="Screen Shot 2021-09-05 at 12 31 46" src="https://user-images.githubusercontent.com/4973774/132113999-79b4337e-151e-49d5-854b-75d4ffbcbe93.png">

https://tfsec.dev/docs/general/general-secrets-sensitive-in-attribute

are no longer valid. The new URL to the web page which describes this alert is now https://tfsec.dev/docs/general/secrets/sensitive-in-attribute, for example.


Since tfsec's JSON output contains `Links` properties which include URLs to the official rule description pages,

```json
{
  "results": [
    {
      "rule_id": "general-secrets-sensitive-in-attribute",
      "legacy_rule_id": "GEN003",
      "rule_description": "Potentially sensitive data stored in block attribute.",
      "rule_provider": "general",
      "impact": "Block attribute could be leaking secrets",
      "resolution": "Don't include sensitive data in blocks",
      "links": [
        "https://tfsec.dev/docs/general/secrets/sensitive-in-attribute#general/secrets",
        "https://www.terraform.io/docs/state/sensitive-data.html"
      ],
      "description": "Block 'module.secret_manager:google_secret_manager_secret_iam_member.xxxxx' includes a potentially sensitive attribute which is defined within the project.",
      "severity": "CRITICAL",
      "status": "failed",
      "location": {
        "filename": ".../...tf",
        "start_line": 26,
        "end_line": 26
      }
    },
    ...
  ]
}

```

we would switch to using these URL links in the PR comments instead of constructing URLs by ourselves.

A new PR comment after this change would be like:

```md
tfsec check general-secrets-sensitive-in-attribute failed.

Block 'module.secret_manager:google_secret_manager_secret_iam_member.xxxxx' includes a potentially sensitive attribute which is defined within the project.

For more information, see:

- https://tfsec.dev/docs/general/secrets/sensitive-in-attribute#general/secrets
- https://www.terraform.io/docs/state/sensitive-data.htm
```


Addresses #18