### PR TITLE
fix(dockerfile): ensure dockerfile gets binary (#1)

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,5 @@
+.git
+.github/
+Dockerfile
+images/
+scripts/

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,12 +1,11 @@
 FROM alpine:3.12
 
-RUN apk --no-cache --update add bash git \
-    && rm -rf /var/cache/apk/*
+RUN apk --no-cache --update add bash git
 
-RUN wget -O - -q "$(wget -q https://api.github.com/repos/aquasecurity/tfsec/releases/latest -O - | grep -o -E "https://.+?tfsec-linux-amd64" | head -n1)" > tfsec \
+RUN wget https://gitreleases.dev/gh/aquasecurity/tfsec/latest/tfsec-linux-arm64 > tfsec \
     && install tfsec /usr/local/bin/
 
-RUN wget -O - -q "$(wget -q https://api.github.com/repos/aquasecurity/tfsec-pr-commenter-action/releases/latest -O - | grep -o -E "https://.+?commenter-linux-amd64")" > commenter \
+RUN wget https://gitreleases.dev/gh/aquasecurity/tfsec-pr-commenter-action/latest/commenter-linux-amd64 > commenter \
     && install commenter /usr/local/bin/
 
 COPY entrypoint.sh /entrypoint.sh


### PR DESCRIPTION
The container image fails to build as it is unable to fetch the proper link for the binaries needed.

This PR includes:

* fix(dockerfile): ensure dockerfile gets binary

* Create .dockerignore