### PR TITLE
updating with force-all-dirs

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -22,7 +22,7 @@ if [ -n "${GITHUB_WORKSPACE}" ]; then
   cd "${GITHUB_WORKSPACE}" || exit
 fi
 
-if ! tfsec --format=json "${INPUT_WORKING_DIRECTORY}" 2>/dev/null >results.json; then
+if ! tfsec --format=json --force-all-dirs "${INPUT_WORKING_DIRECTORY}" 2>/dev/null >results.json; then
   echo "tfsec violations were identified, running commenter..."
   commenter
 fi


### PR DESCRIPTION
Since tfsec does not walk the hierarchy like it used to, this piece should fix the issue that has been reported for issue:

https://github.com/aquasecurity/tfsec-pr-commenter-action/issues/33