### PR TITLE
Remove duplicate comments

### DIFF
--- a/cmd/commenter/commenter.go
+++ b/cmd/commenter/commenter.go
@@ -67,7 +67,7 @@ func main() {
 			}
 		} else {
 			validCommentWritten = true
-			fmt.Printf("Writing comment for %s to %s:%d:%d\n", result.Description, result.Range.Filename, result.Range.StartLine, result.Range.EndLine)
+			fmt.Printf("Commenting for %s to %s:%d:%d\n", result.Description, result.Range.Filename, result.Range.StartLine, result.Range.EndLine)
 		}
 	}
 

--- a/go.mod
+++ b/go.mod
@@ -2,4 +2,4 @@ module github.com/aquasecurity/tfsec-github-commenter-action
 
 go 1.15
 
-require github.com/owenrumney/go-github-pr-commenter v0.0.11
+require github.com/owenrumney/go-github-pr-commenter v0.0.15

--- a/go.sum
+++ b/go.sum
@@ -7,6 +7,12 @@ github.com/google/go-querystring v1.0.0 h1:Xkwi/a1rcvNg1PPYe5vI8GbeBY/jrVuDX5ASu
 github.com/google/go-querystring v1.0.0/go.mod h1:odCYkC5MyYFN7vkCjXpyrEuKhc/BUO6wN/zVPAxq5ck=
 github.com/owenrumney/go-github-pr-commenter v0.0.11 h1:vrOQhNJ7FfBBw//9radv7yuAjL8Tj6lMlhVmkIvLJkg=
 github.com/owenrumney/go-github-pr-commenter v0.0.11/go.mod h1:zsyMXOhg8svtBixUfGqYC3C0woAZOXM9RdEIBMI22ks=
+github.com/owenrumney/go-github-pr-commenter v0.0.13 h1:yoQ5XjQTfKkm/wbZpdo8guACJHA7l/2KD+bgdESTadQ=
+github.com/owenrumney/go-github-pr-commenter v0.0.13/go.mod h1:zsyMXOhg8svtBixUfGqYC3C0woAZOXM9RdEIBMI22ks=
+github.com/owenrumney/go-github-pr-commenter v0.0.14 h1:OoQiWaWWpLyrHRxBM3lM9XAmjQhnt2UGKbFXluCcUoE=
+github.com/owenrumney/go-github-pr-commenter v0.0.14/go.mod h1:FVpyF/OGnWrtYwe9DkRpJsIlxSPIOJstZAyGyDfC/rA=
+github.com/owenrumney/go-github-pr-commenter v0.0.15 h1:QWGW35C3CvkZuYUZ9Jroe2YgN2Rs571R4/m42Ipouek=
+github.com/owenrumney/go-github-pr-commenter v0.0.15/go.mod h1:FVpyF/OGnWrtYwe9DkRpJsIlxSPIOJstZAyGyDfC/rA=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/testify v1.6.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=

--- a/vendor/github.com/owenrumney/go-github-pr-commenter/commenter/commitFileInfo.go
+++ b/vendor/github.com/owenrumney/go-github-pr-commenter/commenter/commitFileInfo.go
@@ -1,10 +1,41 @@
 package commenter
 
+import (
+	"fmt"
+	"strings"
+)
+
 type commitFileInfo struct {
 	FileName  string
 	hunkStart int
 	hunkEnd   int
 	sha       string
+}
+
+func getCommitFileInfo(ghConnector *connector) ([]*commitFileInfo, error) {
+
+	prFiles, err := ghConnector.getFilesForPr()
+	if err != nil {
+		return nil, err
+	}
+
+	var (
+		errs            []string
+		commitFileInfos []*commitFileInfo
+	)
+
+	for _, file := range prFiles {
+		info, err := getCommitInfo(file)
+		if err != nil {
+			errs = append(errs, err.Error())
+			continue
+		}
+		commitFileInfos = append(commitFileInfos, info)
+	}
+	if len(errs) > 0 {
+		return nil, fmt.Errorf("there were errors processing the PR files.\n%s", strings.Join(errs, "\n"))
+	}
+	return commitFileInfos, nil
 }
 
 func (cfi commitFileInfo) calculatePosition(line int) *int {

--- a/vendor/github.com/owenrumney/go-github-pr-commenter/commenter/connector.go
+++ b/vendor/github.com/owenrumney/go-github-pr-commenter/commenter/connector.go
@@ -2,10 +2,14 @@ package commenter
 
 import (
 	"context"
+	"fmt"
+	"time"
 
 	"github.com/google/go-github/v32/github"
 	"golang.org/x/oauth2"
 )
+
+const githubAbuseErrorRetries = 6
 
 type connector struct {
 	prs      *github.PullRequestsService
@@ -21,12 +25,15 @@ type existingComment struct {
 	commentId *int64
 }
 
-func createConnector(token, owner, repo string, prNumber int) *connector {
-	ctx := context.Background()
-	ts := oauth2.StaticTokenSource(&oauth2.Token{AccessToken: token})
-	tc := oauth2.NewClient(ctx, ts)
+type commentFn func() (*github.Response, error)
 
-	client := github.NewClient(tc)
+// create github connector and check if supplied pr number exists
+func createConnector(token, owner, repo string, prNumber int) (*connector, error) {
+
+	client := newGithubClient(token)
+	if _, _, err := client.PullRequests.Get(context.Background(), owner, repo, prNumber); err != nil {
+		return nil, newPrDoesNotExistError(owner, repo, prNumber)
+	}
 
 	return &connector{
 		prs:      client.PullRequests,
@@ -34,41 +41,107 @@ func createConnector(token, owner, repo string, prNumber int) *connector {
 		owner:    owner,
 		repo:     repo,
 		prNumber: prNumber,
+	}, nil
+}
+
+// create github connector and check if supplied pr number exists
+func createEnterpriseConnector(token, baseUrl, uploadUrl, owner, repo string, prNumber int) (*connector, error) {
+
+	client, err := newEnterpriseGithubClient(token, baseUrl, uploadUrl)
+	if err != nil {
+		return nil, err
 	}
+	if _, _, err := client.PullRequests.Get(context.Background(), owner, repo, prNumber); err != nil {
+		return nil, newPrDoesNotExistError(owner, repo, prNumber)
+	}
+
+	return &connector{
+		prs:      client.PullRequests,
+		comments: client.Issues,
+		owner:    owner,
+		repo:     repo,
+		prNumber: prNumber,
+	}, nil
+}
+
+func newGithubClient(token string) *github.Client {
+
+	ctx := context.Background()
+	ts := oauth2.StaticTokenSource(&oauth2.Token{AccessToken: token})
+	tc := oauth2.NewClient(ctx, ts)
+
+	return github.NewClient(tc)
+}
+
+func newEnterpriseGithubClient(token, baseUrl, uploadUrl string) (*github.Client, error) {
+
+	ctx := context.Background()
+	ts := oauth2.StaticTokenSource(&oauth2.Token{AccessToken: token})
+	tc := oauth2.NewClient(ctx, ts)
+
+	client, err := github.NewEnterpriseClient(baseUrl, uploadUrl, tc)
+	if err != nil {
+		return nil, err
+	}
+
+	return client, nil
 }
 
 func (c *connector) writeReviewComment(block *github.PullRequestComment, commentId *int64) error {
-	ctx := context.Background()
 
+	ctx := context.Background()
 	if commentId != nil {
-		var _, err = c.prs.DeleteComment(ctx, c.owner, c.repo, *commentId)
-		if err != nil {
-			return err
-		}
+		return writeCommentWithRetries(c.owner, c.repo, c.prNumber, func() (*github.Response, error) {
+			_, resp, err := c.prs.EditComment(ctx, c.owner, c.repo, *commentId, &github.PullRequestComment{
+				Body: block.Body,
+			})
+			return resp, err
+		})
 	}
-	var _, _, err = c.prs.CreateComment(ctx, c.owner, c.repo, c.prNumber, block)
-	if err != nil {
-		return err
-	}
-	return nil
+
+	return writeCommentWithRetries(c.owner, c.repo, c.prNumber, func() (*github.Response, error) {
+		_, resp, err := c.prs.CreateComment(ctx, c.owner, c.repo, c.prNumber, block)
+		return resp, err
+	})
 }
 
 func (c *connector) writeGeneralComment(comment *github.IssueComment) error {
+
 	ctx := context.Background()
-
-	var _, _, err = c.comments.CreateComment(ctx, c.owner, c.repo, c.prNumber, comment)
-	if err != nil {
-		return err
+	writeReviewCommentFn := func() (*github.Response, error) {
+		_, resp, err := c.comments.CreateComment(ctx, c.owner, c.repo, c.prNumber, comment)
+		return resp, err
 	}
+	return writeCommentWithRetries(c.owner, c.repo, c.prNumber, writeReviewCommentFn)
+}
 
-	return nil
+func writeCommentWithRetries(owner, repo string, prNumber int, commentFn commentFn) error {
+
+	var abuseError AbuseRateLimitError
+	for i := 0; i < githubAbuseErrorRetries; i++ {
+
+		retrySeconds := i * i
+		time.Sleep(time.Second * time.Duration(retrySeconds))
+
+		if resp, err := commentFn(); err != nil {
+			if resp != nil && resp.StatusCode == 422 {
+				abuseError = newAbuseRateLimitError(owner, repo, prNumber, retrySeconds)
+				continue
+			}
+			return fmt.Errorf("write comment: %v", err)
+		}
+		return nil
+	}
+	return abuseError
 }
 
 func (c *connector) getFilesForPr() ([]*github.CommitFile, error) {
+
 	files, _, err := c.prs.ListFiles(context.Background(), c.owner, c.repo, c.prNumber, nil)
 	if err != nil {
 		return nil, err
 	}
+
 	var commitFiles []*github.CommitFile
 	for _, file := range files {
 		if *file.Status != "deleted" {
@@ -79,8 +152,8 @@ func (c *connector) getFilesForPr() ([]*github.CommitFile, error) {
 }
 
 func (c *connector) getExistingComments() ([]*existingComment, error) {
-	ctx := context.Background()
 
+	ctx := context.Background()
 	comments, _, err := c.prs.ListComments(ctx, c.owner, c.repo, c.prNumber, &github.PullRequestListCommentsOptions{})
 	if err != nil {
 		return nil, err
@@ -95,11 +168,4 @@ func (c *connector) getExistingComments() ([]*existingComment, error) {
 		})
 	}
 	return existingComments, nil
-}
-
-func (c *connector) prExists() bool {
-	ctx := context.Background()
-
-	_, _, err := c.prs.Get(ctx, c.owner, c.repo, c.prNumber)
-	return err == nil
 }

--- a/vendor/github.com/owenrumney/go-github-pr-commenter/commenter/errors.go
+++ b/vendor/github.com/owenrumney/go-github-pr-commenter/commenter/errors.go
@@ -21,6 +21,14 @@ type PrDoesNotExistError struct {
 	prNumber int
 }
 
+// AbuseRateLimitError return when the GitHub abuse rate limit is hit
+type AbuseRateLimitError struct {
+	owner            string
+	repo             string
+	prNumber         int
+	BackoffInSeconds int
+}
+
 func newCommentAlreadyWrittenError(filepath, comment string) CommentAlreadyWrittenError {
 	return CommentAlreadyWrittenError{
 		filepath: filepath,
@@ -43,14 +51,27 @@ func (e CommentNotValidError) Error() string {
 	return fmt.Sprintf("There is nothing to comment on at line [%d] in file [%s]", e.lineNo, e.filepath)
 }
 
-func newPrDoesNotExistError(c *connector) PrDoesNotExistError {
+func newPrDoesNotExistError(owner, repo string, prNumber int) PrDoesNotExistError {
 	return PrDoesNotExistError{
-		owner:    c.owner,
-		repo:     c.repo,
-		prNumber: c.prNumber,
+		owner:    owner,
+		repo:     repo,
+		prNumber: prNumber,
 	}
 }
 
 func (e PrDoesNotExistError) Error() string {
 	return fmt.Sprintf("PR number [%d] not found for %s/%s", e.prNumber, e.owner, e.repo)
+}
+
+func newAbuseRateLimitError(owner, repo string, prNumber, backoffInSeconds int) AbuseRateLimitError {
+	return AbuseRateLimitError{
+		owner:            owner,
+		repo:             repo,
+		prNumber:         prNumber,
+		BackoffInSeconds: backoffInSeconds,
+	}
+}
+
+func (e AbuseRateLimitError) Error() string {
+	return fmt.Sprintf("Abuse limit reached on PR [%d] not found for %s/%s", e.prNumber, e.owner, e.repo)
 }

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -4,7 +4,7 @@ github.com/golang/protobuf/proto
 github.com/google/go-github/v32/github
 # github.com/google/go-querystring v1.0.0
 github.com/google/go-querystring/query
-# github.com/owenrumney/go-github-pr-commenter v0.0.11
+# github.com/owenrumney/go-github-pr-commenter v0.0.15
 ## explicit
 github.com/owenrumney/go-github-pr-commenter/commenter
 # golang.org/x/crypto v0.0.0-20200622213623-75b288015ac9
@@ -15,16 +15,12 @@ golang.org/x/crypto/openpgp/elgamal
 golang.org/x/crypto/openpgp/errors
 golang.org/x/crypto/openpgp/packet
 golang.org/x/crypto/openpgp/s2k
-# golang.org/x/lint v0.0.0-20200302205851-738671d3881b
-## explicit
 # golang.org/x/net v0.0.0-20201021035429-f5854403a974
 golang.org/x/net/context
 golang.org/x/net/context/ctxhttp
 # golang.org/x/oauth2 v0.0.0-20180821212333-d2e6202438be
 golang.org/x/oauth2
 golang.org/x/oauth2/internal
-# golang.org/x/tools v0.0.0-20201105220310-78b158585360
-## explicit
 # google.golang.org/appengine v1.1.0
 google.golang.org/appengine/internal
 google.golang.org/appengine/internal/base


### PR DESCRIPTION
 - use the latest version of go-github-pr-commenter to update comments
 - use the backoff functionality to prevent abuse of the API