### PR TITLE
docs: changed tfsec_vars to tfsec_args

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,13 +39,13 @@ There are a number of optional inputs that can be used in the `with:` block.
 
 **tfsec_version** - the version of tfsec to use, defaults to `latest`
 
-**tfsec_vars** - the args of the tfsec to use
+**tfsec_args** - the args of the tfsec to use
 
 **commenter_version** - the version of the commenter to use, defaults to `latest`
 
 **soft_fail_commenter** - set to `true` to to comment silently without breaking the build
 
-### tfsec_vars
+### tfsec_args
 
 `tfsec` provides an [extensive number of arguments](https://aquasecurity.github.io/tfsec/v0.63.1/getting-started/usage/) which can be passed through as in the example below;
 
@@ -64,7 +64,7 @@ jobs:
       - name: tfsec
         uses: aquasecurity/tfsec-pr-commenter-action@v1.0.2
         with:
-          tfsec_vars: --soft-fail
+          tfsec_args: --soft-fail
           github_token: ${{ github.token }}
 ```
 


### PR DESCRIPTION
https://github.com/aquasecurity/tfsec-pr-commenter-action/blob/main/action.yml#:~:text=default%3A%20latest-,tfsec_args%3A,-required%3A%20false

In the README, the argument parameter was tfsec_vars.
So I changed it to tfsec_args.
