### PR TITLE
Workaround missing tfsec release assets

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -2,13 +2,13 @@
 
 set -xe
 
-TFSEC_VERSION="latest"
+TFSEC_VERSION=""
 if [ "$INPUT_TFSEC_VERSION" != "latest" ]; then
-  TFSEC_VERSION="tags/${INPUT_TFSEC_VERSION}"
+  TFSEC_VERSION="/tags/${INPUT_TFSEC_VERSION}"
 fi
 
-wget -O - -q "$(wget -q https://api.github.com/repos/aquasecurity/tfsec/releases/${TFSEC_VERSION} -O - | grep -o -E "https://.+?tfsec-linux-amd64" | head -n1)" > tfsec-linux-amd64
-wget -O - -q "$(wget -q https://api.github.com/repos/aquasecurity/tfsec/releases/${TFSEC_VERSION} -O - | grep -o -E "https://.+?tfsec_checksums.txt" | head -n1)" > tfsec.checksums
+wget -O - -q "$(wget -q https://api.github.com/repos/aquasecurity/tfsec/releases${TFSEC_VERSION} -O - | grep -m 1 -o -E "https://.+?tfsec-linux-amd64" | head -n1)" > tfsec-linux-amd64
+wget -O - -q "$(wget -q https://api.github.com/repos/aquasecurity/tfsec/releases${TFSEC_VERSION} -O - | grep -m 1 -o -E "https://.+?tfsec_checksums.txt" | head -n1)" > tfsec.checksums
 
 grep tfsec-linux-amd64 tfsec.checksums > tfsec-linux-amd64.checksum
 sha256sum -c tfsec-linux-amd64.checksum


### PR DESCRIPTION
If a tfsec release exists, but has no assets, this workflow breaks if
it's set/defaults to latest.

https://github.com/aquasecurity/tfsec/issues/1618

Workaround by using the most recent version that has a correctly
matching asset.