### PR TITLE
Add support for outputting in additional formats other than just `json`

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ jobs:
       - name: Clone repo
         uses: actions/checkout@master
       - name: tfsec
-        uses: aquasecurity/tfsec-pr-commenter-action@v1.0.2
+        uses: aquasecurity/tfsec-pr-commenter-action@v1.1.0
         with:
           github_token: ${{ github.token }}
 ```
@@ -39,7 +39,9 @@ There are a number of optional inputs that can be used in the `with:` block.
 
 **tfsec_version** - the version of tfsec to use, defaults to `latest`
 
-**tfsec_args** - the args of the tfsec to use
+**tfsec_args** - the args for tfsec to use (space-separated)
+
+**tfsec_formats** - the formats for tfsec to output (comma-separated)
 
 **commenter_version** - the version of the commenter to use, defaults to `latest`
 
@@ -47,7 +49,7 @@ There are a number of optional inputs that can be used in the `with:` block.
 
 ### tfsec_args
 
-`tfsec` provides an [extensive number of arguments](https://aquasecurity.github.io/tfsec/v0.63.1/getting-started/usage/) which can be passed through as in the example below;
+`tfsec` provides an [extensive number of arguments](https://aquasecurity.github.io/tfsec/latest/guides/usage/), which can be passed through as in the example below:
 
 ```yaml
 name: tfsec-pr-commenter
@@ -62,10 +64,28 @@ jobs:
       - name: Clone repo
         uses: actions/checkout@master
       - name: tfsec
-        uses: aquasecurity/tfsec-pr-commenter-action@v1.0.2
+        uses: aquasecurity/tfsec-pr-commenter-action@v1.1.0
         with:
           tfsec_args: --soft-fail
           github_token: ${{ github.token }}
+```
+
+### tfsec_formats
+
+`tfsec` provides multiple possible formats for the output:
+
+* default
+* json
+* csv
+* checkstyle
+* junit
+* sarif
+* gif
+
+The `json` format is required and included by default. To add additional formats, set the `tfsec_formats` option to comma-separated values:
+
+```yaml
+tfsec_formats: sarif,csv
 ```
 
 ## Example PR Comment

--- a/action.yml
+++ b/action.yml
@@ -10,7 +10,7 @@ inputs:
     required: false
     description: |
       Directory to run the action on, from the repo root.
-      Default is . ( root of the repository)
+      Default is . (root of the repository)
     default: "."
   tfsec_version:
     required: false
@@ -19,8 +19,13 @@ inputs:
   tfsec_args:
     required: false
     description: |
-      Space seperated args specified here will be added during tfsec execution.
-      (eg. --force-all-dirs --verbose)
+      Space-separated args specified here will be added during tfsec execution.
+      (e.g. --force-all-dirs --verbose)
+  tfsec_formats:
+    required: false
+    description: |
+      Comma-separated formats specified here will be output in addition to json.
+      (e.g. sarif,csv)
   commenter_version:
     required: false
     description: The version of the PR commenter code to run, defaults to latest

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -34,7 +34,12 @@ if [ -n "${INPUT_TFSEC_ARGS}" ]; then
   TFSEC_ARGS_OPTION="${INPUT_TFSEC_ARGS}"
 fi
 
-tfsec --out=results.json --format=json --soft-fail ${TFSEC_ARGS_OPTION} "${INPUT_WORKING_DIRECTORY}" 
+TFSEC_FORMAT_OPTION="json"
+TFSEC_OUT_OPTION="results.json"
+if [ -n "${INPUT_TFSEC_FORMATS}" ]; then
+  TFSEC_FORMAT_OPTION="${TFSEC_FORMAT_OPTION},${INPUT_TFSEC_FORMATS}"
+  TFSEC_OUT_OPTION="${TFSEC_OUT_OPTION%.*}"
+fi
+
+tfsec --out=${TFSEC_OUT_OPTION} --format=${TFSEC_FORMAT_OPTION} --soft-fail ${TFSEC_ARGS_OPTION} "${INPUT_WORKING_DIRECTORY}"
 commenter
-
-


### PR DESCRIPTION
Add a new `tfsec_formats` parameter that can optionally be used to have tfsec output in additional formats.

Fixes #56.