### PR TITLE
use docker image from public ecr to prevent rate limit

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.12
+FROM public.ecr.aws/docker/library/alpine:3.12
 
 RUN apk --no-cache --update add bash git \
     && rm -rf /var/cache/apk/*


### PR DESCRIPTION
when using this action on self-hosted runners, we are facing this issue:

```
toomanyrequests: You have reached your pull rate limit. 
You may increase the limit by authenticating and upgrading: https://www.docker.com/increase-rate-limit
```

does it make sense to use a different registry?

@owenrumney what do you think?