### PR TITLE
fix: append `working_directory` to filename

### DIFF
--- a/cmd/commenter/commenter.go
+++ b/cmd/commenter/commenter.go
@@ -49,9 +49,14 @@ func main() {
 
 	var errMessages []string
 	workspacePath := fmt.Sprintf("%s/", os.Getenv("GITHUB_WORKSPACE"))
+	workingDir := os.Getenv("INPUT_WORKING_DIRECTORY")
+	if workingDir != "" {
+		workingDir = strings.TrimPrefix(workingDir, "./")
+		workingDir = strings.TrimSuffix(workingDir, "/") + "/"
+	}
 	var validCommentWritten bool
 	for _, result := range results {
-		result.Range.Filename = strings.ReplaceAll(result.Range.Filename, workspacePath, "")
+		result.Range.Filename = workingDir + strings.ReplaceAll(result.Range.Filename, workspacePath, "")
 		comment := generateErrorMessage(result)
 		err := c.WriteMultiLineComment(result.Range.Filename, comment, result.Range.StartLine, result.Range.EndLine)
 		if err != nil {


### PR DESCRIPTION
This is a naive solution to https://github.com/aquasecurity/tfsec-pr-commenter-action/issues/54#issuecomment-1101784376

Currently, it appears that if the `working_directory` option is provided when using this action, it fails to lookup files due to path mismatch, which always results in the `.... not writing as not part of the current PR` message.