### PR TITLE
chore: include more printing and some tests

### DIFF
--- a/cmd/commenter/commenter.go
+++ b/cmd/commenter/commenter.go
@@ -12,7 +12,7 @@ import (
 )
 
 func main() {
-	fmt.Println("Starting the github commenter...")
+	fmt.Println("Starting the github commenter")
 
 	token := os.Getenv("INPUT_GITHUB_TOKEN")
 	if len(token) == 0 {
@@ -22,21 +22,20 @@ func main() {
 	githubRepository := os.Getenv("GITHUB_REPOSITORY")
 	split := strings.Split(githubRepository, "/")
 	if len(split) != 2 {
-		fail(fmt.Sprintf("Expected value for split not found. Expected 2 in %v", split))
+		fail(fmt.Sprintf("unexpected value for GITHUB_REPOSITORY. Expected <organisation/name>, found %v", split))
 	}
 	owner := split[0]
 	repo := split[1]
 
+	fmt.Printf("Working in repository %s\n", repo)
+
 	prNo, err := extractPullRequestNumber()
 	if err != nil {
-		fmt.Println("Not a PR, nothing to comment on, exiting...")
+		fmt.Println("Not a PR, nothing to comment on, exiting")
 		return
 	}
+	fmt.Printf("Working in PR %v\n", prNo)
 
-	c, err := commenter.NewCommenter(token, owner, repo, prNo)
-	if err != nil {
-		fail(fmt.Sprintf("failed to create a new commenter. %s", err.Error()))
-	}
 	results, err := loadResultsFile()
 	if err != nil {
 		fail(fmt.Sprintf("failed to load results. %s", err.Error()))
@@ -46,22 +45,31 @@ func main() {
 		fmt.Println("No issues found.")
 		os.Exit(0)
 	}
+	fmt.Printf("TFSec found %v issues\n", len(results))
+
+	c, err := commenter.NewCommenter(token, owner, repo, prNo)
+	if err != nil {
+		fail(fmt.Sprintf("could not connect to GitHub (%s)", err.Error()))
+	}
+
+	workspacePath := fmt.Sprintf("%s/", os.Getenv("GITHUB_WORKSPACE"))
+	fmt.Printf("Working in GITHUB_WORKSPACE %s\n", workspacePath)
 
 	var errMessages []string
-	workspacePath := fmt.Sprintf("%s/", os.Getenv("GITHUB_WORKSPACE"))
 	var validCommentWritten bool
 	for _, result := range results {
 		result.Range.Filename = strings.ReplaceAll(result.Range.Filename, workspacePath, "")
 		comment := generateErrorMessage(result)
+		fmt.Printf("Preparing comment for violation of rule %v in %v\n", result.RuleID, result.Range.Filename)
 		err := c.WriteMultiLineComment(result.Range.Filename, comment, result.Range.StartLine, result.Range.EndLine)
 		if err != nil {
 			// don't error if its simply that the comments aren't valid for the PR
 			switch err.(type) {
 			case commenter.CommentAlreadyWrittenError:
-				fmt.Println("Comment already written so not writing")
+				fmt.Println("Ignoring - comment already written")
 				validCommentWritten = true
 			case commenter.CommentNotValidError:
-				fmt.Printf("%s .... not writing as not part of the current PR\n", result.Description)
+				fmt.Println("Ignoring - change not part of the current PR")
 				continue
 			default:
 				errMessages = append(errMessages, err.Error())
@@ -101,8 +109,10 @@ For more information, see:
 }
 
 func extractPullRequestNumber() (int, error) {
-	file, err := ioutil.ReadFile("/github/workflow/event.json")
+	github_event_file := "/github/workflow/event.json"
+	file, err := ioutil.ReadFile(github_event_file)
 	if err != nil {
+		fail(fmt.Sprintf("GitHub event payload not found in %s", github_event_file))
 		return -1, err
 	}
 
@@ -129,6 +139,6 @@ func formatUrls(urls []string) string {
 }
 
 func fail(err string) {
-	fmt.Printf("The commenter failed with the following error:\n%s\n", err)
+	fmt.Printf("Error: %s\n", err)
 	os.Exit(-1)
 }

--- a/tests/results.json
+++ b/tests/results.json
@@ -1,0 +1,50 @@
+{
+	"results": [
+		{
+			"rule_id": "AVD-AWS-0030",
+			"long_id": "aws-ecr-enable-image-scans",
+			"rule_description": "ECR repository has image scans disabled.",
+			"rule_provider": "aws",
+			"rule_service": "ecr",
+			"impact": "The ability to scan images is not being used and vulnerabilities will not be highlighted",
+			"resolution": "Enable ECR image scanning",
+			"links": [
+				"https://aquasecurity.github.io/tfsec/v1.19.1/checks/aws/ecr/enable-image-scans/",
+				"https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/ecr_repository#image_scanning_configuration"
+			],
+			"description": "Image scanning is not enabled.",
+			"severity": "HIGH",
+			"warning": false,
+			"status": 0,
+			"resource": "image_scanning_configuration.foobarrr.scan_on_push",
+			"location": {
+				"filename": "/github/workspace/vendor/modules.txt",
+				"start_line": 7,
+				"end_line": 7
+			}
+		},
+		{
+			"rule_id": "AVD-AWS-0031",
+			"long_id": "aws-ecr-enforce-immutable-repository",
+			"rule_description": "ECR images tags shouldn't be mutable.",
+			"rule_provider": "aws",
+			"rule_service": "ecr",
+			"impact": "Image tags could be overwritten with compromised images",
+			"resolution": "Only use immutable images in ECR",
+			"links": [
+				"https://aquasecurity.github.io/tfsec/v1.19.1/checks/aws/ecr/enforce-immutable-repository/",
+				"https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/ecr_repository"
+			],
+			"description": "Repository tags are mutable.",
+			"severity": "HIGH",
+			"warning": false,
+			"status": 0,
+			"resource": "aws_ecr_repository.foobarrr.image_tag_mutability",
+			"location": {
+				"filename": "/github/workspace/go.mod",
+				"start_line": 5,
+				"end_line": 5
+			}
+		}
+	]
+}

--- a/tests/results.json
+++ b/tests/results.json
@@ -16,7 +16,7 @@
 			"severity": "HIGH",
 			"warning": false,
 			"status": 0,
-			"resource": "image_scanning_configuration.foobarrr.scan_on_push",
+			"resource": "image_scanning_configuration.scan_on_push",
 			"location": {
 				"filename": "/github/workspace/vendor/modules.txt",
 				"start_line": 7,

--- a/tests/run.sh
+++ b/tests/run.sh
@@ -1,0 +1,2 @@
+#!/usr/bin/env bash
+docker run --rm -it -w /src -v $(PWD):/src:ro -e GITHUB_TOKEN alpine sh -c "./tests/setup.sh"

--- a/tests/setup.sh
+++ b/tests/setup.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env sh
+echo "* Running in a container"
+
+export GITHUB_REPOSITORY=aquasecurity/tfsec-pr-commenter-action
+export GITHUB_WORKSPACE=/github/workspace
+export INPUT_GITHUB_TOKEN=${GITHUB_TOKEN}
+
+mkdir -p /github/workflow
+mkdir -p /github/workspace/vendor
+
+# Here we pretend to be a real PR where a file is changed in a directory:
+# https://github.com/aquasecurity/tfsec-pr-commenter-action/pull/43
+cat >/github/workflow/event.json<<EOF
+{"number":43}
+EOF
+
+# Mock the file changed in this PR (vendor/modules.txt)
+for i in seq 1 10; do
+  echo this is line $i >> ${GITHUB_WORKSPACE}/vendor/modules.txt
+done
+
+# Mock another file in this PR, this time in / (go.mod)
+for i in seq 1 10; do
+  echo this is line $i >> ${GITHUB_WORKSPACE}/go.mod
+done
+
+cp ./bin/commenter-linux-amd64 ${GITHUB_WORKSPACE}/
+cp ./tests/results.json ${GITHUB_WORKSPACE}/
+cd $GITHUB_WORKSPACE
+
+# This will run through the PR and WRITE A COMMENT!
+./commenter-linux-amd64

--- a/vendor/github.com/owenrumney/go-github-pr-commenter/commenter/commenter.go
+++ b/vendor/github.com/owenrumney/go-github-pr-commenter/commenter/commenter.go
@@ -155,12 +155,16 @@ func (c *Commenter) writeCommentIfRequired(prComment *github.PullRequestComment)
 func (c *Commenter) checkCommentRelevant(filename string, line int) bool {
 
 	for _, file := range c.files {
+		fmt.Printf("File changed in PR %v: ", file.FileName)
 		if relevant := func(file *commitFileInfo) bool {
 			if file.FileName == filename && !file.isResolvable() {
+				fmt.Printf("issue at L%v, PR change between L%v and L%v... ", line, file.hunkStart, file.hunkEnd)
 				if line >= file.hunkStart && line <= file.hunkEnd {
+					fmt.Println("match")
 					return true
 				}
 			}
+			fmt.Println("ignoring")
 			return false
 		}(file); relevant {
 			return true


### PR DESCRIPTION
This is a simple attempt at easing local development. Given a
GITHUB_TOKEN this will work and write a comment to the PR defined in
tests/setup.sh (a real PR with files changed).