### PR TITLE
Download the correct version of the commenter

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -14,7 +14,7 @@ grep tfsec-linux-amd64 tfsec.checksums > tfsec-linux-amd64.checksum
 sha256sum -c tfsec-linux-amd64.checksum
 install tfsec-linux-amd64 /usr/local/bin/tfsec
 
-COMMENTER_VERSION="latest"
+COMMENTER_VERSION="tags/${GITHUB_ACTION_REF}"
 if [ "$INPUT_COMMENTER_VERSION" != "latest" ]; then
   COMMENTER_VERSION="tags/${INPUT_COMMENTER_VERSION}"
 fi


### PR DESCRIPTION
It seems more logical to download the version specified in the github action declaration instead of latest.

We can always specify a version with `commenter_version` input.

Fixes https://github.com/aquasecurity/tfsec-pr-commenter-action/issues/72