### PR TITLE
Fixes #85 - Prevent extra empty string argument

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -63,5 +63,5 @@ if [ -n "${INPUT_TFSEC_FORMATS}" ]; then
   TFSEC_OUT_OPTION="${TFSEC_OUT_OPTION%.*}"
 fi
 
-tfsec --out=${TFSEC_OUT_OPTION} --format="${TFSEC_FORMAT_OPTION}" --soft-fail "${TFSEC_ARGS_OPTION}" "${INPUT_WORKING_DIRECTORY}"
+tfsec --out=${TFSEC_OUT_OPTION} --format="${TFSEC_FORMAT_OPTION}" --soft-fail ${TFSEC_ARGS_OPTION} "${INPUT_WORKING_DIRECTORY}"
 commenter


### PR DESCRIPTION
Not 100% sure if this is the right fix, but looking at the error in #85 the quotes that have been removed here seemed to be the cause.