### PR TITLE
Disable bash debug output by default

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-set -xe
+set -e
 
 if [ -z "${INPUT_GITHUB_TOKEN}" ] ; then
   echo "Consider setting a GITHUB_TOKEN to prevent GitHub api rate limits." >&2


### PR DESCRIPTION
Bash debug output is enabled by default causing very verbose output and hiding more important details in a workflow run